### PR TITLE
Support limited api tags and fix memoization instance collisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "Cython",
   "hatchling",
   "setuptools",
+  "packaging",
   "typing_extensions; python_version < '3.10'"
 ]
 description = 'Cython build hooks for hatch'

--- a/src/hatch_cython/plugin.py
+++ b/src/hatch_cython/plugin.py
@@ -9,6 +9,8 @@ from tempfile import TemporaryDirectory
 
 from Cython.Tempita import sub as render_template
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+from hatchling.builders.macos import process_macos_plat_tag
+from packaging.tags import sys_tags
 
 from hatch_cython.config import parse_from_dict
 from hatch_cython.constants import (
@@ -339,10 +341,50 @@ class CythonBuildHook(BuildHookInterface):
         if self.sdist and not self.options.compiled_sdist:
             self.clean(None)
 
-        build_data["infer_tag"] = True
+        abi3_tag = self._limited_api_tag()
+        if abi3_tag is None:
+            build_data["infer_tag"] = True
+        else:
+            build_data["infer_tag"] = False
+            build_data["tag"] = abi3_tag
         build_data["artifacts"].extend(self.artifacts)
         build_data["force_include"].update(self.inclusion_map)
         build_data["pure_python"] = False
 
         self.app.display_info("Extensions complete")
         self.app.display_debug(build_data)
+
+    def _limited_api_tag(self):
+        py_limited_api = self.options.compile_kwargs.get("py_limited_api")
+        if not py_limited_api:
+            return None
+
+        minimum = None
+        macro_length = 2
+        for macro in self.options.define_macros:
+            if not macro:
+                continue
+            if macro[0] != "Py_LIMITED_API" or len(macro) < macro_length:
+                continue
+
+            version_str = macro[1]
+            if version_str:
+                try:
+                    version = int(version_str, 16)
+                except ValueError:
+                    continue
+                minimum = (version >> 24) & 0xFF, (version >> 16) & 0xFF
+                break
+
+        if minimum is None:
+            minimum = (sys.version_info.major, sys.version_info.minor)
+
+        # Logic is taken from hatchling.builders.wheel.WheelBuilder.get_best_matching_tag
+        tag = next(iter(t for t in sys_tags() if "manylinux" not in t.platform and "musllinux" not in t.platform))
+        platform = tag.platform
+
+        if sys.platform == "darwin":
+            platform = process_macos_plat_tag(platform, compat=self.config.get("macos_max_compat", False))
+
+        major, minor = minimum
+        return f"cp{major}{minor}-abi3-{platform}"

--- a/src/hatch_cython/utils.py
+++ b/src/hatch_cython/utils.py
@@ -1,6 +1,7 @@
 import os
 import platform
 from textwrap import dedent
+from weakref import WeakKeyDictionary
 
 from Cython import __version__ as __cythonversion__
 
@@ -16,24 +17,18 @@ def stale(src: str, dest: str):
 
 
 def memo(func: CallableT[P, T]) -> CallableT[P, T]:
-    keyed = {}
+    # Use WeakKeyDictionary for instances to avoid memory leaks
+    # and use a separate dict/list for static/module functions
+    instance_keyed = WeakKeyDictionary()
+    static_keyed = {}
 
     def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
-        nonlocal keyed
-
-        # if we have a class, memo will reserve objects between
-        # instances, so we need to key this by the id of the instance
-        # note: dont call hasattr here because hasattr is pretty much
-        # a try catch for property access - ergo we get infinite recursive
-        # calls if a property is memoed
-        if len(args) != 0 and func.__name__ in dir(args[0]):
-            idof = id(args[0])
-        else:
-            idof = None
-
-        if idof not in keyed:
-            keyed[idof] = func(*args, **kwargs)
-        return keyed[idof]
+        is_method = len(args) != 0 and func.__name__ in dir(args[0])
+        key = args[0] if is_method else None
+        cache = instance_keyed if is_method else static_keyed
+        if key not in cache:
+            cache[key] = func(*args, **kwargs)
+        return cache[key]
 
     return wrapped
 

--- a/tests/test_limited_api.py
+++ b/tests/test_limited_api.py
@@ -1,0 +1,101 @@
+import sys
+from os import getcwd
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import PropertyMock, patch
+
+from hatch_cython.plugin import CythonBuildHook
+
+from .utils import arch_platform
+
+
+def test_limited_api_tag():
+    # Mocking minimum to be 3.8 (0x03080000)
+    options = {"options": {"py_limited_api": True, "define_macros": [["Py_LIMITED_API", "0x03080000"]]}}
+
+    with patch("hatch_cython.plugin.sys_tags") as mock_tags:
+        mock_tag = SimpleNamespace(platform="win_amd64")
+        mock_tags.return_value = iter([mock_tag])
+
+        root = Path(getcwd())
+        hook = CythonBuildHook(
+            root,
+            options,
+            {},
+            SimpleNamespace(name="example_lib"),
+            directory=root,
+            target_name="wheel",
+        )
+
+        tag = hook._limited_api_tag()
+        assert tag == "cp38-abi3-win_amd64"
+
+
+def test_limited_api_tag_no_macro():
+    options = {"options": {"py_limited_api": True}}
+
+    with patch("hatch_cython.plugin.sys_tags") as mock_tags:
+        mock_tag = SimpleNamespace(platform="win_amd64")
+        mock_tags.return_value = iter([mock_tag])
+
+        root = Path(getcwd())
+        hook = CythonBuildHook(
+            root,
+            options,
+            {},
+            SimpleNamespace(name="example_lib"),
+            directory=root,
+            target_name="wheel",
+        )
+
+        major, minor = sys.version_info.major, sys.version_info.minor
+        tag = hook._limited_api_tag()
+        assert tag == f"cp{major}{minor}-abi3-win_amd64"
+
+
+def test_limited_api_disabled():
+    options = {"options": {"py_limited_api": False}}
+
+    root = Path(getcwd())
+    hook = CythonBuildHook(
+        root,
+        options,
+        {},
+        SimpleNamespace(name="example_lib"),
+        directory=root,
+        target_name="wheel",
+    )
+
+    tag = hook._limited_api_tag()
+    assert tag is None
+
+
+def test_initialize_with_limited_api():
+    options = {"options": {"py_limited_api": True, "define_macros": [["Py_LIMITED_API", "0x03090000"]]}}
+
+    with arch_platform("x86_64", "linux"):
+        with patch("hatch_cython.plugin.sys_tags") as mock_tags:
+            mock_tag = SimpleNamespace(platform="linux_x86_64")
+            mock_tags.return_value = iter([mock_tag])
+
+            root = Path(getcwd())
+            hook = CythonBuildHook(
+                root,
+                options,
+                {},
+                SimpleNamespace(name="example_lib"),
+                directory=root,
+                target_name="wheel",
+            )
+
+            # Mocking build_ext and grouped_included_files
+            with (
+                patch.object(CythonBuildHook, "build_ext"),
+                patch.object(CythonBuildHook, "grouped_included_files", new_callable=PropertyMock) as mock_grouped,
+            ):
+                mock_grouped.return_value = []
+                build_data = {"artifacts": [], "force_include": {}}
+                hook.initialize("0.1.0", build_data)
+
+                assert build_data["infer_tag"] is False
+                assert build_data["tag"] == "cp39-abi3-linux_x86_64"


### PR DESCRIPTION
This PR fixes:

- Extracts cp version from Py_LIMITED_API macro 
- Fixes memoization bug where id() reuse caused cross-instance state leak

When adding the tests, I came accross the `memo` bug function which can appear quite frequently on CI.
Tests pass. The failed ones seems related to virtualenv 21.0 from hatch on Python 3.8 and 3.9.